### PR TITLE
Feat: API 호출 실패 시 모의 데이터 반환으로 fetchChartSongs 메서드 수정

### DIFF
--- a/src/api/MusicClient.ts
+++ b/src/api/MusicClient.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
 import { ISong } from '../types/types';
+import mockData from '../data/mock.json';
 
 const apiUrl = process.env.REACT_APP_API_URL;
 
@@ -20,12 +21,13 @@ export default class MusicClient {
 			) {
 				return response.data.data;
 			} else {
-				console.warn('Empty or invalid API response');
-				return [];
+				console.warn('Empty or invalid API response, returning mock data.');
+				return mockData.data;
 			}
 		} catch (error) {
 			console.error('API fetch error:', error);
-			throw error;
+			console.warn('API fetch error, returning mock data.');
+			return mockData.data;
 		}
 	}
 }


### PR DESCRIPTION
## 개요
서버 API 개발 중 또는 서버 접근이 불가능한 환경에서의 개발 편의성을 높이기 위해 MusicClient의 fetchChartSongs 메서드가 API 호출에 실패했을 때 모의 데이터를 반환하도록 수정되었습니다.


## 작업 사항
- MusicClient 클래스의 fetchChartSongs 메서드 수정
- 모의 데이터(mock.json) 파일을 프로젝트에 추가/활용
- 에러 발생 시 콘솔에 경고 메시지 출력 후 모의 데이터 반환 로직 구현


## 변경 로직

### 변경 전
API 호출 실패 시 또는 응답 데이터가 비어 있거나 유효하지 않은 경우, 콘솔에 경고를 출력하고 빈 배열을 반환하도록 설정되어 있었습니다.

```
if (
    response.data &&
    Array.isArray(response.data.data) &&
    response.data.data.length > 0
) {
    return response.data.data;
} else {
    console.warn('Empty or invalid API response');
    return [];
}
```


### 변경 후
API 호출 실패 시 또는 응답 데이터가 비어 있거나 유효하지 않은 경우, 콘솔에 경고를 출력하고 모의 데이터를 반환하도록 수정되었습니다.

```
if (
    response.data &&
    Array.isArray(response.data.data) &&
    response.data.data.length > 0
) {
    return response.data.data;
} else {
    console.warn('Empty or invalid API response, returning mock data.');
    return mockData.data; // 목데이터 반환
}
```


## 사용 방법
이 변경사항은 서버 API가 개발 중이거나 서버에 접근할 수 없는 환경에서 개발을 진행하는 경우 유용합니다. 사용 방법은 기존과 동일하나, API 호출이 실패하면 자동으로 모의 데이터를 사용하게 됩니다. 개발자는 API 서버의 상태에 관계없이 프론트엔드의 개발 및 테스트를 이어갈 수 있습니다.

