### PR TITLE
Refactor: 로딩 및 뮤직 모달의 z-index와 초기 상태 관리 로직 개선

### DIFF
--- a/src/components/buttons/ModalButtonManager.tsx
+++ b/src/components/buttons/ModalButtonManager.tsx
@@ -4,36 +4,43 @@ import ModalButton from './ModalButton';
 import { ModalType } from '../../types/modalTypes';
 import { MODAL_CONFIGS } from '../../configs/modalConfigs';
 
+type MainModalType = Exclude<ModalType, 'addSong' | 'loading'>;
+
 const ModalButtonManager = () => {
 	const { modalsState, toggleMinimizeModal, openModal, openedModals } = useModalStore();
 
-	const handleToggleMinimize = (modalType: ModalType) => () => {
+	const handleToggleMinimize = (modalType: MainModalType) => () => {
 		toggleMinimizeModal(modalType);
 	};
 
-	const handleOpenModal = (modalType: ModalType) => () => {
+	const handleOpenModal = (modalType: MainModalType) => () => {
 		openModal(modalType);
 	};
 
 	return (
 		<>
 			{openedModals
-				.filter((modalType) => !['addSong'].includes(modalType))
+				.filter(
+					(modalType): modalType is MainModalType =>
+						!['addSong', 'loading'].includes(modalType),
+				)
 				.map((modalType) => {
 					const modalInfo = modalsState[modalType];
 					if (!modalInfo || !modalInfo.isOpen) return null;
-					const { icon: Icon, label } = MODAL_CONFIGS[modalType];
+					const config = MODAL_CONFIGS[modalType];
+					if (!('icon' in config && 'label' in config)) return null;
 
+					const { icon: Icon, label } = config;
 					return (
 						<ModalButton
 							key={modalType}
-							modalType={modalType as ModalType}
+							modalType={modalType}
 							open={modalInfo.isOpen}
 							isMinimized={modalInfo.isMinimized}
-							toggleMinimize={handleToggleMinimize(modalType as ModalType)}
+							toggleMinimize={handleToggleMinimize(modalType)}
 							icon={<Icon />}
 							label={label}
-							onOpen={handleOpenModal(modalType as ModalType)}
+							onOpen={handleOpenModal(modalType)}
 						/>
 					);
 				})}

--- a/src/components/modals/AddSongModal.tsx
+++ b/src/components/modals/AddSongModal.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler, useRef, useState } from 'react';
+import React, { CSSProperties, MouseEventHandler, useRef, useState } from 'react';
 import Modal from './Modal';
 import Button from '../buttons/Button';
 import { ModalType } from '../../types/modalTypes';
@@ -7,9 +7,10 @@ import { MODAL_CONFIGS } from '../../configs/modalConfigs';
 interface IAddSongModal {
 	open: boolean;
 	onClose: MouseEventHandler<HTMLButtonElement>;
+	style: CSSProperties;
 }
 
-const AddSongModal = ({ open, onClose }: IAddSongModal) => {
+const AddSongModal = ({ open, onClose, style }: IAddSongModal) => {
 	const AddSongModalRef = useRef(null);
 	const { key } = MODAL_CONFIGS.addSong;
 
@@ -35,7 +36,7 @@ const AddSongModal = ({ open, onClose }: IAddSongModal) => {
 			open={open}
 			onClose={handleClose}
 			modalRef={AddSongModalRef}
-			style={{ zIndex: 100 }}
+			style={style}
 			modalKey={key as ModalType}
 		>
 			<div className="flex flex-col justify-center px-20 py-10 space-y-1">

--- a/src/components/modals/LoadingModal.tsx
+++ b/src/components/modals/LoadingModal.tsx
@@ -2,8 +2,6 @@ import React, { MouseEventHandler, useRef } from 'react';
 import Modal from './Modal';
 import { MODAL_CONFIGS } from '../../configs/modalConfigs';
 import { ModalType } from '../../types/modalTypes';
-import { useModalStore } from '../../stores/useModalStore';
-
 interface ILoadingModalProps {
 	open: boolean;
 	style: React.CSSProperties;
@@ -13,25 +11,19 @@ interface ILoadingModalProps {
 const LoadingModal = ({ open, style, onClose }: ILoadingModalProps) => {
 	const loadingModalRef = useRef(null);
 	const { key } = MODAL_CONFIGS.loading;
+	const safeZIndex = typeof style.zIndex === 'number' ? style.zIndex + 2 : 9999;
 
-	const { currentHighestZIndex } = useModalStore((state) => ({
-		currentHighestZIndex: state.currentHighestZIndex,
-	}));
-
-	const loadingModalZIndex = currentHighestZIndex + 1;
-
-	const modalStyle = {
+	const updatedStyle = {
 		...style,
-		zIndex: loadingModalZIndex,
+		zIndex: safeZIndex,
 	};
 
 	return (
-		<div className="fixed inset-0 flex items-center justify-center">
+		<div style={updatedStyle} className="fixed inset-0 flex items-center justify-center">
 			<Modal
 				open={open}
 				onClose={onClose}
 				modalRef={loadingModalRef}
-				style={modalStyle}
 				modalKey={key as ModalType}
 			>
 				<div className="flex items-center justify-center w-[289px] h-[150px] text-black">

--- a/src/components/modals/Modal.tsx
+++ b/src/components/modals/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, MouseEventHandler, RefObject, useLayoutEffect } from 'react';
+import React, { MouseEvent, MouseEventHandler, RefObject, useEffect, useLayoutEffect } from 'react';
 import useDrag from '../../hooks/useDrag';
 import Frame from '../Frame';
 import ModalHeader from './ModalHeader';
@@ -36,18 +36,35 @@ const Modal = ({
 	modalRef,
 	modalKey,
 }: IModalComponentProps) => {
-	const { modalsState } = useModalStore();
+	const {
+		modalsState,
+
+		incrementZIndex,
+		currentHighestZIndex,
+		setModalZIndexes,
+		setCurrentHighestModal,
+	} = useModalStore((state) => ({
+		modalsState: state.modalsState,
+
+		incrementZIndex: state.incrementZIndex,
+		currentHighestZIndex: state.currentHighestZIndex,
+		setModalZIndexes: state.setModalZIndexes,
+		setCurrentHighestModal: state.setCurrentHighestModal,
+	}));
 	const modalInfo = modalsState[modalKey];
-	const zIndex = modalInfo?.zIndex;
+	const zIndex = modalInfo.zIndex;
 
 	const { modalPos, handleMouseDown, handleMouseMove, handleMouseUp, handleMouseLeave } =
 		useDrag(modalRef);
 
-	useLayoutEffect(() => {
-		if (modalRef && 'current' in modalRef && modalRef.current) {
-			modalRef.current.style.transform = `translate(${modalPos.x}px, ${modalPos.y}px)`;
+	useEffect(() => {
+		if (open && !modalInfo.isMinimized && (modalKey === 'addSong' || modalKey === 'loading')) {
+			const newZIndex = currentHighestZIndex + 1;
+			setModalZIndexes(modalKey, newZIndex);
+			setCurrentHighestModal(modalKey);
+			incrementZIndex();
 		}
-	}, [modalPos, modalRef]);
+	}, [open, modalInfo.isMinimized, modalKey]);
 
 	if (!open) return null;
 

--- a/src/stores/useModalStore.tsx
+++ b/src/stores/useModalStore.tsx
@@ -36,14 +36,14 @@ const createInitialModalsState = (modalKeys: ModalType[]): ModalStateType => {
 	const state: Partial<ModalStateType> = {};
 	for (const key of modalKeys) {
 		if (key === 'music') {
-			state[key] = { isOpen: true, zIndex: 5, isMinimized: false };
+			state[key] = { isOpen: true, zIndex: 6, isMinimized: false };
 		} else {
 			state[key] = { isOpen: false, zIndex: 0, isMinimized: false };
 		}
 	}
 	return state as ModalStateType;
 };
-const ModalKeysArray: ModalType[] = ['music', 'chart', 'signIn', 'signUp'];
+const ModalKeysArray: ModalType[] = ['music', 'chart', 'signIn', 'signUp', 'loading', 'addSong'];
 
 const initialModalZIndexes = createInitialModalZIndexes(ModalKeysArray, 5);
 const initialModalsState = createInitialModalsState(ModalKeysArray);
@@ -51,7 +51,7 @@ const initialModalsState = createInitialModalsState(ModalKeysArray);
 export const useModalStore = create<IModalStore>((set, get) => ({
 	modalsState: initialModalsState,
 	currentHighestZIndex: 5,
-	currentHighestModal: 'music',
+	currentHighestModal: null,
 	modalZIndexes: initialModalZIndexes,
 	openedModals: ['music'],
 	setModalsState: (newState: ModalStateType) => set(() => ({ modalsState: newState })),

--- a/src/types/modalTypes.ts
+++ b/src/types/modalTypes.ts
@@ -1,1 +1,1 @@
-export type ModalType = 'music' | 'chart' | 'signIn' | 'signUp';
+export type ModalType = 'music' | 'chart' | 'signIn' | 'signUp' | 'loading' | 'addSong';


### PR DESCRIPTION
## 개요

이 PR은 애플리케이션 내에서 로딩 모달의 z-index 관리 로직을 개선하기 위한 것입니다. 로딩 모달이 다른 모든 모달 위에 올바르게 표시되도록 z-index를 동적으로 조정하며, 모달 관리 상태 로직 내에서의 z-index 업데이트 방식을 개선했습니다.

## 작업 사항

- 로딩 모달의 z-index를 조건에 따라 동적으로 조정하는 로직을 구현하여, 로딩 모달이 항상 최상위에 위치하도록 변경했습니다.
- `useModalStore` 내에서 모달의 z-index 업데이트 방식을 개선했습니다.
- `ModalButton` 및 `Modal` 컴포넌트의 `useEffect`를 사용하여 상태 변경 시 로직을 반영하도록 개선했습니다.

## 변경 로직

### 변경 전

- 로딩 모달의 z-index가 고정값으로 설정되어 있어, 다른 모달들과의 상대적 위치가 바뀔 수 있었습니다.

### 변경 후

- 로딩 모달의 z-index가 다른 모달들이 열리는 상황에 따라 동적으로 최상위 값을 가지도록 조정됩니다.

## 사용 방법

변경된 로직은 애플리케이션 내부적으로 처리되므로, 사용자는 이러한 변경 사항에 대해 별도의 조치를 취할 필요가 없습니다. 애플리케이션을 사용하는 과정에서 로딩 모달의 개선된 동작을 자연스럽게 경험할 수 있습니다.
