### PR TITLE
Feat: 차트 데이터를 수동으로 업데이트하는 기능 추가

### DIFF
--- a/src/components/modals/ChartModal.tsx
+++ b/src/components/modals/ChartModal.tsx
@@ -7,10 +7,9 @@ import { Drvspace7 } from '@react95/icons';
 import Frame from '../Frame';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faClock } from '@fortawesome/free-regular-svg-icons';
-import { faPlay, faPlus } from '@fortawesome/free-solid-svg-icons';
-import { useQuery } from '@tanstack/react-query';
+import { faPlay, faPlus, faRedo } from '@fortawesome/free-solid-svg-icons';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import useMusicPlayer from '../../hooks/useMusicPlayer';
-
 import { ModalType } from '../../types/modalTypes';
 import { useMusicService } from '../../hooks/useMusicService';
 import { MODAL_CONFIGS } from '../../configs/modalConfigs';
@@ -29,6 +28,7 @@ const ChartModal = ({ open, style, onClose, onMinimize, onOpen, playerRef }: ICh
 	const { key } = MODAL_CONFIGS.chart;
 	const musicService = useMusicService();
 	const { handleSongClick } = useMusicPlayer({ playerRef });
+	const queryClient = useQueryClient();
 
 	const {
 		data: songs,
@@ -41,6 +41,10 @@ const ChartModal = ({ open, style, onClose, onMinimize, onOpen, playerRef }: ICh
 	if (isError) {
 		console.error('Failed to fetch songs using React Query', error);
 	}
+
+	const refetchSongs = () => {
+		queryClient.invalidateQueries(['songs']);
+	};
 
 	return (
 		<>
@@ -56,17 +60,21 @@ const ChartModal = ({ open, style, onClose, onMinimize, onOpen, playerRef }: ICh
 				style={style}
 				modalKey={key as ModalType}
 			>
-				<div className="flex items-center justify-between px-1 py-2">
-					<div className="flex items-center">
+				<div className="flex flex-col px-1 py-2">
+					<div className="flex items-start justify-between">
 						<h2 className="text-lg font-bold lg:text-xl font-eng">TOP100</h2>
-						<span className="mt-1 ml-1 text-xs">
-							{formatDate(songs?.[0]?.rankDate)}
-						</span>
+						<Button onClick={refetchSongs} className="px-3 py-[1px] text-xs">
+							Refresh
+							<FontAwesomeIcon icon={faRedo} size="sm" className="ml-1" />
+						</Button>
 					</div>
-					<p className="flex items-center mt-1 text-xs">
-						<FontAwesomeIcon className="mr-2" icon={faClock} />
-						매일 12시 00분에 업데이트됩니다.
-					</p>
+					<div className="flex justify-between">
+						<span className="text-xs">{formatDate(songs?.[0]?.rankDate)}</span>
+						<p className="flex items-center text-xs">
+							<FontAwesomeIcon icon={faClock} className="mr-1" />
+							매일 12시 00분에 업데이트됩니다.
+						</p>
+					</div>
 				</div>
 				<Frame className="overflow-y-auto max-h-96" boxShadow="in" bg="white">
 					{songs?.map((song: ISong, index: number) => (


### PR DESCRIPTION
## 개요
사용자가 차트 데이터를 수동으로 업데이트할 수 있도록 React Query를 사용하여 수동 리패치 기능을 추가하였습니다. 이를 통해 사용자는 최신 차트 정보를 실시간으로 확인할 수 있으며, 데이터 동기화를 유지할 수 있습니다.


## 작업 사항
1. React Query의 useQueryClient를 사용하여 queryClient 인스턴스를 생성.
2. ChartModal 컴포넌트 내에 리패치 버튼을 추가하고, 해당 버튼에 refetchSongs 함수를 연결하여 데이터 리패치를 수행.
3. refetchSongs 함수에서는 queryClient.invalidateQueries 메서드를 사용하여 특정 쿼리('songs')를 무효화하고 자동으로 다시 가져오도록 설정.


## 변경 로직

### 변경 전
차트 데이터는 자동으로 주기적으로 업데이트되었으나, 사용자가 직접 데이터를 갱신할 수 있는 방법이 제공되지 않았습니다.

### 변경 후
사용자가 버튼을 클릭하면 useQueryClient를 통해 획득한 queryClient의 invalidateQueries 메소드를 호출하여 'songs' 쿼리를 수동으로 리패치하도록 변경하였습니다. 이 과정에서 리액트 쿼리의 캐시가 무효화되고, 서버에서 새로운 데이터를 가져오도록 요청합니다.

```
const refetchSongs = () => {
    queryClient.invalidateQueries(['songs']);
};

```



## 사용 방법
이 변경 사항은 사용자가 최신 차트 데이터를 수동으로 요청할 필요가 있을 때 유용합니다. 리패치 버튼을 클릭하기만 하면 즉시 서버로부터 최신 데이터를 가져오게 됩니다. 이 기능은 특히 API에서 주기적인 업데이트가 이루어지지 않는 경우나 테스트 중 데이터 갱신이 필요할 때 효과적입니다.

